### PR TITLE
Return and Result url are essential

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Paynow Zimbabwe Python SDK
 
-Python SDK for Paynow Zimbabwe's API
+- Python SDK for Paynow Zimbabwe's API
 
 # Prerequisites
 
-This library has a set of prerequisites that must be met for it to work
+- This library has a set of prerequisites that must be met for it to work
 
 1.  requests
 
 # Installation
 
-Install the library using pip
+- Install the library using pip
 
 ```sh
-$ pip install paynow
+$ pip3 install paynow
 ```
 
-and import the Paynow class into your project
+- import the Paynow class into your project
 
 ```python
 	from paynow import Paynow
@@ -34,8 +34,8 @@ Create an instance of the Paynow class optionally setting the result and return 
 paynow = Paynow(
 	'INTEGRATION_ID',
 	'INTEGRATION_KEY',
-	'http://google.com',
-	'http://google.com'
+	'http://yourweb.com/returnurl', # merchant return url
+	'http://yourweb.com/results',   # merchant result url
 	)
 ```
 
@@ -60,7 +60,7 @@ When you're finally ready to send your payment to Paynow, you can use the `send`
 response = paynow.send(payment)
 ```
 
-The response from Paynow will b have some useful information like whether the request was successful or not. If it was, for example, it contains the url to redirect the user so they can make the payment. You can view the full list of data contained in the response in our wiki
+The response from Paynow will be having some useful information like whether the request was successful or not. If it was, for example, it contains the url to redirect the user so they can make the payment. You can view the full list of data contained in the response in our wiki
 
 If request was successful, you should consider saving the poll url sent from Paynow in the database
 
@@ -118,12 +118,11 @@ else :
 ```python
 from paynow import Paynow
 
-
 paynow = Paynow(
 	'INTEGRATION_ID',
 	'INTEGRATION_KEY',
-	'http://google.com',
-	'http://google.com'
+	'http://yourweb.com/returnurl', # merchant return url
+	'http://yourweb.com/results',   # merchant result url
 	)
 
 payment = paynow.create_payment('Order', 'test@example.com')

--- a/paynow/model.py
+++ b/paynow/model.py
@@ -111,18 +111,18 @@ class InitResponse:
     """
 
     def __init__(self, data):
+        # TODO return dict of kwargs
+
         self.status = data['status']
         self.success = data['status'].lower() != 'error'
         self.has_redirect = 'browserurl' in data
         self.hash = 'hash' in data
 
         if not self.success:
+            self.error = data['error']
             return
 
         self.poll_url = data['pollurl']
-
-        if not self.success:
-            self.error = data['error']
 
         if self.has_redirect:
             self.redirect_url = data['browserurl']


### PR DESCRIPTION
- The Response object from Paynow is too vague. Since this is an API why not make this a json response with all the information on success?
- Since most applications using this API would be web based i think the return and result urls are essential not optional.
-- Paynow should redirect the client to the return url automatically on success on the url set by the merchant
-- Paynow should sent results of the transaction to the mercant's results url or portal whichever way h/her backend is configured
- Create two methods separate ie for mobile payments why should i select the method for now? Why not make it an attribute of the Paynow object.