### PR TITLE
Skip Encoding result_url and return_url

### DIFF
--- a/paynow/model.py
+++ b/paynow/model.py
@@ -419,8 +419,6 @@ class Paynow:
 
         """
         body = {
-            "resulturl": self.result_url,
-            "returnurl": self.return_url,
             "reference": payment.reference,
             "amount": payment.total(),
             "id": self.integration_id,
@@ -432,6 +430,8 @@ class Paynow:
         for key, value in body.items():
             body[key] = quote_plus(str(value))
 
+        body['resulturl'] = self.result_url
+        body['returnurl'] = self.return_url
         body['hash'] = self.__hash(body, self.integration_key)
 
         return body

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='paynow',  # Required
-    version='1.0.2',  # Required
+    version='1.0.3',  # Required
     description='Paynow Python SDK',  # Required
     long_description=long_description,  # Optional
     long_description_content_type='text/markdown',  # Optional (see note above)


### PR DESCRIPTION
Skipping fields _result_url_ and _return_url_ when urlencoding transaction information as it was triggering an error on the Paynow server resulting in failed redirects